### PR TITLE
add missing semicolon in test

### DIFF
--- a/t/05.longcol.t
+++ b/t/05.longcol.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More;
 use rlib '../lib';
 use Test::More;
-use Array::Columnize::columnize
+use Array::Columnize::columnize;
 
 note( "Testing when width is less than one of the items" );
 my $data = ["what's", "upppppppppppppppppp"];


### PR DESCRIPTION
Without the semicolon, the return value of the following statement was passed as an argument to the module's import method. Future versions are intending to make passing arguments to an undefined import method an error.